### PR TITLE
redirect verbose commen to stderr, to avoid stored in rootfs.tar file

### DIFF
--- a/build.bash
+++ b/build.bash
@@ -6,7 +6,7 @@ case "$1" in
 	;;
     --second-stage)
 	chroot /rootfs mount -t proc proc /proc
-	chroot /rootfs /debootstrap/debootstrap --second-stage
+	chroot /rootfs /debootstrap/debootstrap --second-stage 1>&2
 	tar -C /rootfs -cf - .
 	;;
 esac


### PR DESCRIPTION
in curren setup, we had following rootfs.tar, this failed to run `docker import` command

head rootfs.tar
`
I: Keyring file not available at /usr/share/keyrings/ubuntu-archive-keyring.gpg; switching to https mirror https://mirrors.kernel.org/debian
I: Installing core packages...
I: Unpacking required packages...
I: Unpacking adduser...
I: Unpacking base-files...
I: Unpacking base-passwd...
I: Unpacking bash...
I: Unpacking bsdutils...
I: Unpacking busybox-initramfs...
I: Unpacking coreutils...
I: Unpacking cpio...
`
